### PR TITLE
Fix signal and server

### DIFF
--- a/source/include/dqm4hep/Client.h
+++ b/source/include/dqm4hep/Client.h
@@ -126,11 +126,9 @@ namespace dqm4hep {
        *
        *  @param  serviceName the service name
        *  @param  pController the controller class handling the service update
-       *  @param  function the controller method hadling the service update
        */
       template <typename Controller>
-      void unsubscribe(const std::string &serviceName, Controller *pController,
-                       void (Controller::*function)(const Buffer &));
+      void unsubscribe(const std::string &serviceName, Controller *pController);
 
       /**
        *  @brief  Whether this client already registered a service subscription
@@ -250,13 +248,12 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
 
     template <typename Controller>
-    inline void Client::unsubscribe(const std::string &serviceName, Controller *pController,
-                                    void (Controller::*function)(const Buffer &)) {
+    inline void Client::unsubscribe(const std::string &serviceName, Controller *pController) {
       for (auto iter = m_serviceHandlerMap.begin(), endIter = m_serviceHandlerMap.end(); endIter != iter; ++iter) {
         if (serviceName != iter->first)
           continue;
 
-        if (iter->second->onServiceUpdate().disconnect(pController, function))
+        if (iter->second->onServiceUpdate().disconnect(pController))
           break;
       }
     }

--- a/source/src/Server.cc
+++ b/source/src/Server.cc
@@ -28,6 +28,7 @@
 // -- dqm4hep headers
 #include <dqm4hep/Internal.h>
 #include <dqm4hep/Server.h>
+#include <dqm4hep/Logging.h>
 
 // -- std headers
 #include <sys/utsname.h>
@@ -373,6 +374,10 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
 
     bool Server::serviceAlreadyRunning(const std::string &name) {
+      if(DimServer::inCallback()) {
+        dqm_warning( "Server::serviceAlreadyRunning: can't check for duplicated service on network !" );
+        return false;
+      }
       DimBrowser browser;
       int nServices = browser.getServices(name.c_str());
 
@@ -398,6 +403,10 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
 
     bool Server::requestHandlerAlreadyRunning(const std::string &name) {
+      if(DimServer::inCallback()) {
+        dqm_warning( "Server::requestHandlerAlreadyRunning: can't check for duplicated request handler on network !" );
+        return false;
+      }
       DimBrowser browser;
       int nServices = browser.getServices(name.c_str());
 
@@ -423,6 +432,10 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
 
     bool Server::commandHandlerAlreadyRunning(const std::string &name) {
+      if(DimServer::inCallback()) {
+        dqm_warning( "Server::commandHandlerAlreadyRunning: can't check for duplicated command on network !" );
+        return false;
+      }
       DimBrowser browser;
       int nServices = browser.getServices(name.c_str());
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Server
   - Added protection on calling DimBrowser in a server callback. This causes deadlock internally for DIM library
- Client
   - Fixed `unsubscribe` function prototype to match the Signal class function in DQMCore

ENDRELEASENOTES