### PR TITLE
Export libs fix

### DIFF
--- a/.travis-ci.d/install_dependencies.sh
+++ b/.travis-ci.d/install_dependencies.sh
@@ -38,8 +38,6 @@ cd ../..
 git clone https://github.com/dqm4hep/dqm4hep-core.git
 cd dqm4hep-core
 mkdir -p build && cd build
-cmake -DDQM4HEP_DOXYGEN_DOC=OFF -Dxdrstream_DIR=$PWD/../dependencies/xdrstream -DCMAKE_MODULE_PATH=$PWD/../dependencies/dqm4hep/cmake -DDQM4HEP_TESTING=ON -DDQM4HEP_WARNING_AS_ERROR=ON -DDQM4HEP_DEV_WARNINGS=ON ..
-
 cmake -DDQM4HEP_DOXYGEN_DOC=OFF -Dxdrstream_DIR=$PWD/../../xdrstream -DCMAKE_MODULE_PATH=$PWD/../../dqm4hep/cmake -DDQM4HEP_TESTING=OFF -DDQM4HEP_WARNING_AS_ERROR=OFF -DDQM4HEP_DEV_WARNINGS=OFF ..
 
 if [ $? -ne 0 ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ display_std_variables()
 
 ###############################
 # generate and install following configuration files
-dqm4hep_generate_package_confguration( 
+dqm4hep_generate_package_configuration( 
   PACKAGE ${PROJECT_NAME}
   LIBRARIES ${PROJECT_NAME} dim
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,4 +64,7 @@ display_std_variables()
 
 ###############################
 # generate and install following configuration files
-dqm4hep_generate_package_confguration( PACKAGE ${PROJECT_NAME} )
+dqm4hep_generate_package_confguration( 
+  PACKAGE ${PROJECT_NAME}
+  LIBRARIES ${PROJECT_NAME} dim
+)


### PR DESCRIPTION

BEGINRELEASENOTES
- Export library export: libdim.so was missing leading to linking error on dqm4hep-online

ENDRELEASENOTES