### PR TITLE
Set version to v01-00-00

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required( VERSION 2.6 FATAL_ERROR )
 # project name
 project( DQMNet )
 
-set( ${PROJECT_NAME}_VERSION_MAJOR 0 )
+set( ${PROJECT_NAME}_VERSION_MAJOR 1 )
 set( ${PROJECT_NAME}_VERSION_MINOR 0 )
 set( ${PROJECT_NAME}_VERSION_PATCH 0 )
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Set version to v01-00-00 instead of v00-00-00. Major version 0 causes problem to cmake when calling `find_package` from external CMake files 

ENDRELEASENOTES